### PR TITLE
New sequencer

### DIFF
--- a/pymeasure/display/widgets/sequencer_widget.py
+++ b/pymeasure/display/widgets/sequencer_widget.py
@@ -315,31 +315,32 @@ class SequenceDialog(QtWidgets.QFileDialog):
         self._setup_ui()
 
     def _setup_ui(self):
+        preview_tab = QtWidgets.QTabWidget()
+        vbox = QtWidgets.QVBoxLayout()
+        param_vbox = QtWidgets.QVBoxLayout()
+        vbox_widget = QtWidgets.QWidget()
+        param_vbox_widget = QtWidgets.QWidget()
+
+        self.preview_param = SequencerTreeView(parent=self)
+        triggers = QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers
+        self.preview_param.setEditTriggers(triggers)
+        param_vbox.addWidget(self.preview_param)
+        vbox_widget.setLayout(vbox)
+        param_vbox_widget.setLayout(param_vbox)
+        preview_tab.addTab(param_vbox_widget, "Sequence Parameters")
         if not self.save:
             self.append_checkbox = QtWidgets.QCheckBox("Append to existing sequence")
-            preview_tab = QtWidgets.QTabWidget()
-            vbox = QtWidgets.QVBoxLayout()
-            param_vbox = QtWidgets.QVBoxLayout()
-            vbox_widget = QtWidgets.QWidget()
-            param_vbox_widget = QtWidgets.QWidget()
-
-            self.preview_param = SequencerTreeView(parent=self)
-            triggers = QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers
-            self.preview_param.setEditTriggers(triggers)
-            param_vbox.addWidget(self.preview_param)
-            vbox_widget.setLayout(vbox)
-            param_vbox_widget.setLayout(param_vbox)
-            preview_tab.addTab(param_vbox_widget, "Sequence Parameters")
+            self.append_checkbox.setCheckState(QtCore.Qt.CheckState.Checked)
             self.layout().addWidget(self.append_checkbox)
-            self.layout().addWidget(preview_tab, 0, 5, 4, 1)
-            self.layout().setColumnStretch(5, 1)
-            self.setMinimumSize(900, 500)
-            self.resize(900, 500)
             self.setFileMode(QtWidgets.QFileDialog.FileMode.ExistingFile)
-            self.currentChanged.connect(self.update_preview)
         else:
             self.setAcceptMode(QtWidgets.QFileDialog.AcceptSave)
             self.setFileMode(QtWidgets.QFileDialog.FileMode.AnyFile)
+        self.layout().addWidget(preview_tab, 0, 5, 4, 1)
+        self.layout().setColumnStretch(5, 1)
+        self.setMinimumSize(900, 500)
+        self.resize(900, 500)
+        self.currentChanged.connect(self.update_preview)
 
     def update_preview(self, filename):
         if not os.path.isdir(filename) and filename != '':

--- a/pymeasure/display/widgets/sequencer_widget.py
+++ b/pymeasure/display/widgets/sequencer_widget.py
@@ -312,6 +312,7 @@ class SequenceDialog(QtWidgets.QFileDialog):
         Generate a serialized form of the sequence tree
 
         :param save: True if we are saving a file. Default False.
+        :param parent: Passed on to QtWidgets.QWidget. Default is None
         """
         super().__init__(parent)
         self.save = save

--- a/pymeasure/display/widgets/sequencer_widget.py
+++ b/pymeasure/display/widgets/sequencer_widget.py
@@ -42,7 +42,7 @@ class SequencerTreeModel(QtCore.QAbstractItemModel):
         :param parent: A QWidget that QT will give ownership of this Widget to.
     """
 
-    def __init__(self, data, header=["Level", "Parameter", "Sequence"], parent=None):
+    def __init__(self, data, header=("Level", "Parameter", "Sequence"), parent=None):
         super().__init__(parent)
 
         self.header = header

--- a/pymeasure/display/widgets/sequencer_widget.py
+++ b/pymeasure/display/widgets/sequencer_widget.py
@@ -563,8 +563,7 @@ class SequencerWidget(QtWidgets.QWidget):
             if dialog.exec():
                 append_flag = dialog.append_checkbox.checkState() == QtCore.Qt.CheckState.Checked
                 filenames = dialog.selectedFiles()
-                if filenames:
-                    filename = filenames[0]
+                filename = filenames[0]
             else:
                 return
 

--- a/pymeasure/display/widgets/sequencer_widget.py
+++ b/pymeasure/display/widgets/sequencer_widget.py
@@ -557,13 +557,14 @@ class SequencerWidget(QtWidgets.QWidget):
         :param filename: Filename (string) of the to-be-loaded file.
         """
         append_flag = False
+
         if (filename is None) or (filename == ''):
             dialog = SequenceDialog()
-            dialog.exec()
-            append_flag = dialog.append_checkbox.checkState() == QtCore.Qt.CheckState.Checked
-            filenames = dialog.selectedFiles()
-            if filenames:
-                filename = filenames[0]
+            if dialog.exec():
+                append_flag = dialog.append_checkbox.checkState() == QtCore.Qt.CheckState.Checked
+                filenames = dialog.selectedFiles()
+                if filenames:
+                    filename = filenames[0]
             else:
                 return
 

--- a/pymeasure/display/widgets/sequencer_widget.py
+++ b/pymeasure/display/widgets/sequencer_widget.py
@@ -294,6 +294,10 @@ class SequencerTreeView(QtWidgets.QTreeView):
 
     def setModel(self, model):
         super().setModel(model)
+        width = self.viewport().size().width()
+        self.setColumnWidth(0, int(0.7 * width))
+        self.setColumnWidth(1, int(0.9 * width))
+        self.setColumnWidth(2, int(0.9 * width))
         self.model().layoutChanged.connect(self.activate_persistent_editor)
 
 
@@ -417,10 +421,6 @@ class SequencerWidget(QtWidgets.QWidget):
     def _setup_ui(self):
         self.tree = SequencerTreeView(self)
         self.tree.setHeaderHidden(False)
-        width = self.tree.viewport().size().width()
-        self.tree.setColumnWidth(0, int(0.7 * width))
-        self.tree.setColumnWidth(1, int(0.9 * width))
-        self.tree.setColumnWidth(2, int(0.9 * width))
         self.tree.setItemDelegateForColumn(1, ComboBoxDelegate(self, self.names_choices))
         self.tree.setItemDelegateForColumn(2, LineEditDelegate(self))
         self.load_seq_button = QtWidgets.QPushButton("Load sequence")

--- a/pymeasure/display/widgets/sequencer_widget.py
+++ b/pymeasure/display/widgets/sequencer_widget.py
@@ -182,7 +182,7 @@ class SequencerTreeModel(QtCore.QAbstractItemModel):
             as the way of finding out what to display where.
         """
         if orientation == QtCore.Qt.Orientation.Horizontal and \
-           role == QtCore.Qt.ItemDataRole.DisplayRole:
+                role == QtCore.Qt.ItemDataRole.DisplayRole:
             return self.header[section]
 
     def setData(self, index, value, role=QtCore.Qt.ItemDataRole.EditRole):
@@ -275,6 +275,11 @@ class LineEditDelegate(QtWidgets.QStyledItemDelegate):
 
 
 class SequencerTreeView(QtWidgets.QTreeView):
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.width = self.viewport().size().width()
+
     def save(self, filename=None):
         self.model().save(filename)
 
@@ -296,10 +301,9 @@ class SequencerTreeView(QtWidgets.QTreeView):
 
     def setModel(self, model):
         super().setModel(model)
-        width = self.viewport().size().width()
-        self.setColumnWidth(0, int(0.7 * width))
-        self.setColumnWidth(1, int(0.9 * width))
-        self.setColumnWidth(2, int(0.9 * width))
+        self.setColumnWidth(0, int(0.7 * self.width))
+        self.setColumnWidth(1, int(0.9 * self.width))
+        self.setColumnWidth(2, int(0.9 * self.width))
         self.model().layoutChanged.connect(self.activate_persistent_editor)
 
 

--- a/pymeasure/experiment/sequencer.py
+++ b/pymeasure/experiment/sequencer.py
@@ -132,7 +132,7 @@ class SequenceHandler:
         'tanh': numpy.tanh,
     }
 
-    def __init__(self, valid_inputs=[], file_obj=None):
+    def __init__(self, valid_inputs=(), file_obj=None):
         self._sequences = []
         self.valid_inputs = valid_inputs
         if file_obj:

--- a/tests/experiment/test_sequencer.py
+++ b/tests/experiment/test_sequencer.py
@@ -75,7 +75,7 @@ def test_sequencer(seq_file_text):
     file_text, levels, children, params = seq_file_text
     fd = StringIO(file_text)
 
-    s = SequenceHandler(fd)
+    s = SequenceHandler(file_obj=fd)
     assert(len(s) == non_empty_lines(file_text))
 
     for index, lev in enumerate(levels):
@@ -122,5 +122,5 @@ def test_sequencer_errors(seq_file_text_err):
     fd = StringIO(file_text)
 
     with pytest.raises(exception, match=exc_text):
-        seq = SequenceHandler(fd)
+        seq = SequenceHandler(file_obj=fd)
         seq.parameters_sequence()


### PR DESCRIPTION
Set default to append_checkbox to checked for backwards compatibility.

Add preview pane when saving files. User may not know the file name of the current file, and after making changes to the sequence they can preview a sequence file before overwriting it.

