### PR TITLE
Add linewidth argument to ManagedDockWindow

### DIFF
--- a/pymeasure/display/windows/managed_dock_window.py
+++ b/pymeasure/display/windows/managed_dock_window.py
@@ -45,6 +45,7 @@ class ManagedDockWindow(ManagedWindowBase):
     :param y_axis: the data column(s) for the y-axis of the plot. This may be a string or a list
         of strings from the data columns of the procedure. The list length determines the number of
         plots
+    :param linewidth: linewidth for the displayed curves, default is 1
     :param log_fmt: formatting string for the log-widget
     :param log_datefmt: formatting string for the date in the log-widget
     :param \\**kwargs: optional keyword arguments that will be passed to
@@ -52,7 +53,7 @@ class ManagedDockWindow(ManagedWindowBase):
     """
 
     def __init__(self, procedure_class, x_axis=None, y_axis=None,
-                 log_fmt=None, log_datefmt=None, **kwargs):
+                 linewidth=1, log_fmt=None, log_datefmt=None, **kwargs):
 
         self.x_axis = x_axis
         self.y_axis = y_axis
@@ -79,11 +80,8 @@ class ManagedDockWindow(ManagedWindowBase):
             measure_quantities.append(self.y_axis)
 
         self.log_widget = LogWidget("Experiment Log", fmt=log_fmt, datefmt=log_datefmt)
-        dock_widget_kwargs = {}
-        if 'linewidth' in kwargs:
-            dock_widget_kwargs['linewidth'] = kwargs['linewidth']
         self.dock_widget = DockWidget("Dock Tab", procedure_class, self.x_axis_labels,
-                                      self.y_axis_labels, **dock_widget_kwargs)
+                                      self.y_axis_labels, linewidth=linewidth)
 
         if "widget_list" not in kwargs:
             kwargs["widget_list"] = ()


### PR DESCRIPTION
As is, relying on a kwarg argument will not work. That is because `**kwargs` gets passed to [`ManagedWindowBase`](https://github.com/pymeasure/pymeasure/blob/59ac50bd7bccf627c49d7f7f08cbf465214b830e/pymeasure/display/windows/managed_dock_window.py#L89), which doesn't process `**kwargs` itself, so if there is a passed argument that isn't `ManagedWindowBase.__init__()`, then it will result in a `TypeError: ManagedWindowBase.__init__() got an unexpected keyword argument 'kwargs'` error.

There are few workarounds, for instance `linewidth` could be deleted from `**kwargs` before being passed to `ManagedWindowBase`.

Instead, we can modify `ManagedDockWindow` to accept `linewidth` argument directly, which is similar to [`ManagedWindow`](https://github.com/pymeasure/pymeasure/blob/59ac50bd7bccf627c49d7f7f08cbf465214b830e/pymeasure/display/windows/managed_window.py#L605-L612).

This PR makes that change.

All that being said, I think almost all widget plot styling options (linewidth, background, symbol, etc) should be passed as `**kwargs` in the future. `ManagedWindowBase` should accept it `**kwargs`. But I think that change should be done for all widgets, and that may require a standard approach to styling rules and naming scheme. That should be a different PR though.
